### PR TITLE
HTS-1166: Fix response when AccountAlreadyExists

### DIFF
--- a/app/uk/gov/hmrc/helptosaveapi/models/EligibilityResponse.scala
+++ b/app/uk/gov/hmrc/helptosaveapi/models/EligibilityResponse.scala
@@ -44,9 +44,9 @@ object EligibilityResponse {
       json.asOpt[ApiEligibilityResponse] match {
         case Some(eligibilityResponse) ⇒ JsSuccess(eligibilityResponse)
         case None ⇒
-          (json \ "accountExists").asOpt[String] match {
-            case Some(data) ⇒ JsSuccess(AccountAlreadyExists())
-            case None       ⇒ JsError(s"couldn't parse eligibility json from mongo, json=$json")
+          json.\ ("accountExists").as[Boolean] match {
+            case true  ⇒ JsSuccess(AccountAlreadyExists())
+            case false ⇒ JsError(s"couldn't parse eligibility json from mongo, json=$json")
           }
       }
     }

--- a/app/uk/gov/hmrc/helptosaveapi/models/EligibilityResponse.scala
+++ b/app/uk/gov/hmrc/helptosaveapi/models/EligibilityResponse.scala
@@ -22,15 +22,24 @@ sealed trait EligibilityResponse
 
 object EligibilityResponse {
 
-  implicit val apiEligibilityResponseWrites: Writes[ApiEligibilityResponse] = Json.writes[ApiEligibilityResponse]
-
   implicit val writes: Writes[EligibilityResponse] = new Writes[EligibilityResponse] {
+    implicit val apiEligibilityResponseWrites: Writes[ApiEligibilityResponse] = Json.writes[ApiEligibilityResponse]
     override def writes(response: EligibilityResponse): JsValue = {
       response match {
         case a: ApiEligibilityResponse ⇒
           Json.toJson(a)
         case b: AccountAlreadyExists ⇒
           Json.parse("""{"accountExists": true}""")
+      }
+    }
+  }
+
+  implicit val reads: Reads[EligibilityResponse] = new Reads[EligibilityResponse] {
+    implicit val apiEligibilityResponseReads: Reads[ApiEligibilityResponse] = Json.reads[ApiEligibilityResponse]
+    override def reads(json: JsValue): JsResult[EligibilityResponse] = {
+      json.asOpt[ApiEligibilityResponse] match {
+        case Some(eligibilityResponse) ⇒ JsSuccess(eligibilityResponse)
+        case None                      ⇒ JsSuccess(AccountAlreadyExists())
       }
     }
   }

--- a/app/uk/gov/hmrc/helptosaveapi/models/EligibilityResponse.scala
+++ b/app/uk/gov/hmrc/helptosaveapi/models/EligibilityResponse.scala
@@ -44,9 +44,9 @@ object EligibilityResponse {
       json.asOpt[ApiEligibilityResponse] match {
         case Some(eligibilityResponse) ⇒ JsSuccess(eligibilityResponse)
         case None ⇒
-          json.\ ("accountExists").as[Boolean] match {
-            case true  ⇒ JsSuccess(AccountAlreadyExists())
-            case false ⇒ JsError(s"couldn't parse eligibility json from mongo, json=$json")
+          json.\ ("accountExists").asOpt[Boolean] match {
+            case Some(true)  ⇒ JsSuccess(AccountAlreadyExists())
+            case _ ⇒ JsError(s"couldn't parse eligibility json from mongo, json=$json")
           }
       }
     }

--- a/app/uk/gov/hmrc/helptosaveapi/repo/EligibilityStore.scala
+++ b/app/uk/gov/hmrc/helptosaveapi/repo/EligibilityStore.scala
@@ -24,16 +24,16 @@ import play.api.libs.json.{JsValue, Json}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import uk.gov.hmrc.cache.model.Id
 import uk.gov.hmrc.cache.repository.CacheMongoRepository
-import uk.gov.hmrc.helptosaveapi.models.Eligibility
+import uk.gov.hmrc.helptosaveapi.models.{Eligibility, EligibilityResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[MongoEligibilityStore])
 trait EligibilityStore {
 
-  def get(correlationId: UUID)(implicit ec: ExecutionContext): Future[Either[String, Option[Eligibility]]]
+  def get(correlationId: UUID)(implicit ec: ExecutionContext): Future[Either[String, Option[EligibilityResponse]]]
 
-  def put(correlationId: UUID, eligibility: Eligibility)(implicit ec: ExecutionContext): Future[Either[String, Unit]]
+  def put(correlationId: UUID, eligibility: EligibilityResponse)(implicit ec: ExecutionContext): Future[Either[String, Unit]]
 
 }
 
@@ -45,16 +45,16 @@ class MongoEligibilityStore @Inject() (config: Configuration,
 
   private lazy val cacheRepository = new CacheMongoRepository("api-eligibility", expireAfterSeconds)(mongo.mongoConnector.db, ec)
 
-  override def get(correlationId: UUID)(implicit ec: ExecutionContext): Future[Either[String, Option[Eligibility]]] = {
+  override def get(correlationId: UUID)(implicit ec: ExecutionContext): Future[Either[String, Option[EligibilityResponse]]] = {
     doFindById(Id(correlationId.toString)).map { maybeCache ⇒
-      Right(maybeCache.flatMap(_.data.map(value ⇒ (value \ "eligibility").as[Eligibility])))
+      Right(maybeCache.flatMap(_.data.map(value ⇒ (value \ "eligibility").as[EligibilityResponse])))
     }.recover {
       case e ⇒
         Left(e.getMessage)
     }
   }
 
-  override def put(correlationId: UUID, eligibility: Eligibility)(implicit ec: ExecutionContext): Future[Either[String, Unit]] = {
+  override def put(correlationId: UUID, eligibility: EligibilityResponse)(implicit ec: ExecutionContext): Future[Either[String, Unit]] = {
     doCreateOrUpdate(Id(correlationId.toString), "eligibility", Json.toJson(eligibility)).map[Either[String, Unit]] {
       dbUpdate ⇒
         if (dbUpdate.writeResult.inError) {


### PR DESCRIPTION
```
Sureshs-MacBook-Pro:help-to-save suresh$ curl -v -H "Gov-Vendor-Instance-ID: fa7c484c-d8cf-4f8a-a39c-54a2a4c04bc6" -H "Gov-Vendor-Version: 1.3" -H "Accept: application/vnd.hmrc.2.0+json" -H "Content-Type: application/json" -H "Gov-Client-User-ID: AE123456C" -H "Gov-Client-Timezone: UTC" -H "Authorization: Bearer 5c22b4e6c31dbacfb9678912dcf1490" -d '{"header":{"version":"2.0","createdTimestamp":"2017-11-22 23:11:09 GMT","clientCode":"KCOM","requestCorrelationId":"1b41e841-5dd9-485a-b2cf-477e8ef5572b"},"body":{"nino":"AE123456C","forename":"Alex","surname":"Brown","dateOfBirth":"19920423","contactDetails":{"address1":"44, quicksilver","address2":"Blackpool","postcode":"FY43 1FB","communicationPreference":"00"},"registrationChannel":"callCentre"}}' "http://localhost:7004/account"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 7004 (#0)
> POST /account HTTP/1.1
> Host: localhost:7004
> User-Agent: curl/7.54.0
> Gov-Vendor-Instance-ID: fa7c484c-d8cf-4f8a-a39c-54a2a4c04bc6
> Gov-Vendor-Version: 1.3
> Accept: application/vnd.hmrc.2.0+json
> Content-Type: application/json
> Gov-Client-User-ID: AE123456C
> Gov-Client-Timezone: UTC
> Authorization: Bearer 5c22b4e6c31dbacfb9678912dcf1490
> Content-Length: 403
> 
* upload completely sent off: 403 out of 403 bytes
< HTTP/1.1 409 Conflict
< Cache-Control: no-cache,no-store,max-age=0
< X-XSS-Protection: 1; mode=block
< Content-Length: 0
< Date: Fri, 03 Aug 2018 13:13:31 GMT
< 
* Connection #0 to host localhost left intact
Sureshs-MacBook-Pro:help-to-save suresh$ 
```