### PR TITLE
DLS-5623 Fix Scaladoc/Wartremover

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,7 @@ lazy val microservice = Project(appName, file("."))
     retrieveManaged := false
   )
   .settings(scalacOptions += "-Xcheckinit")
+  .settings(Compile / scalacOptions -= "utf8")
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.20")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.6")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.3")
 


### PR DESCRIPTION
 - Removes -utf8 option added by wartremover which trips up scaladoc (common Wartremover problem) on autogenerated files
 - Updates wartremover